### PR TITLE
DUPLO-9835: Support arm64 docker native

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -204,6 +204,7 @@ jobs:
     if: "${{ startsWith(github.event.inputs.image_version, 'release-') && github.event.inputs.only_partition == 'all' }}"
     needs:
       - build-commercial
+      - build-govcloud
     steps:
       # Get the code for the image JSON generation, and the code for Duplo master.
       - name: Checkout duplo-infra

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -159,7 +159,7 @@ jobs:
 
           # Parse build options.
           if [ "$ONLY_BUILDERS" = "all" ]; then
-            ONLY_BUILDERS="-only=amazon-ebs.ubuntu-20,amazon-ebs.ubuntu-22,amazon-ebs.amazonlinux-2"
+            ONLY_BUILDERS="-except=amazon-ebs.ubuntu-18"
           elif [ -n "$ONLY_BUILDERS" ]; then
             ONLY_BUILDERS="-only=$ONLY_BUILDERS"
           fi

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -159,7 +159,7 @@ jobs:
 
           # Parse build options.
           if [ "$ONLY_BUILDERS" = "all" ]; then
-            ONLY_BUILDERS="-except=amazon-ebs.ubuntu-18"
+            ONLY_BUILDERS="-except=amazon-ebs.ubuntu-18,googlecompute.ubuntu-20,googlecompute.ubuntu-22"
           elif [ -n "$ONLY_BUILDERS" ]; then
             ONLY_BUILDERS="-only=$ONLY_BUILDERS"
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Ignore packer manifest
 packer-manifest.json
+govcloud-packer-manifest.json
 snippet-*.json
 *.pkrvars.json
 

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,23 @@
+# See: https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app
+# See: https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml
+
+[pr_reviewer]
+enable_review_labels_effort = true
+
+[pr_description]
+add_original_user_description = true
+keep_original_user_title = true
+
+[github_app]
+handle_pr_actions = ['opened', 'reopened', 'ready_for_review', 'review_requested']
+pr_commands = [
+    "/describe",
+    "/review",
+    "/update_changelog --pr_update_changelog.push_changelog_changes=true"
+]
+handle_push_trigger = true
+push_commands = [
+    "/describe",
+    "/review -i --pr_reviewer.remove_previous_review_comment=true",
+    "/update_changelog"
+]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+## 2024-02-07
+
+### Added
+- Introduced support for ARM64 architecture in Docker native image generation.
+- Added ARM64 builds for Ubuntu 20, Ubuntu 22, Amazon Linux 2, and Amazon Linux 2023 in AWS Packer configurations.
+- Updated the main Packer build configuration to include ARM64 versions.
+
+### Changed
+- Modified the GitHub Actions workflow to exclude Ubuntu 18 from the build process, facilitating ARM64 build integration.

--- a/packer/aws.pkr.hcl
+++ b/packer/aws.pkr.hcl
@@ -437,119 +437,118 @@ source "amazon-ebs" "amazonlinux-2-arm64" {
   }
 }
 
+// source "amazon-ebs" "amazonlinux-2023" {
+//   ami_name                    = "${local.image_family}-al2023-${local.image_version}"
+//   ami_description             = "${local.image_description} (al2023)"
+//   instance_type               = var.aws_instance_type
+//   region                      = var.aws_region
+//   vpc_id                      = var.aws_vpc_id
+//   subnet_id                   = var.aws_subnet_id
+//   security_group_id           = var.aws_security_group_id
+//   iam_instance_profile        = var.aws_iam_instance_profile
+//   associate_public_ip_address = true
 
-source "amazon-ebs" "amazonlinux-2023" {
-  ami_name                    = "${local.image_family}-al2023-${local.image_version}"
-  ami_description             = "${local.image_description} (al2023)"
-  instance_type               = var.aws_instance_type
-  region                      = var.aws_region
-  vpc_id                      = var.aws_vpc_id
-  subnet_id                   = var.aws_subnet_id
-  security_group_id           = var.aws_security_group_id
-  iam_instance_profile        = var.aws_iam_instance_profile
-  associate_public_ip_address = true
+// 	temporary_key_pair_type = var.temporary_key_pair_type
+// 	ssh_username            = "ec2-user"
+//   ssh_interface           = "session_manager"
 
-	temporary_key_pair_type = var.temporary_key_pair_type
-	ssh_username            = "ec2-user"
-  ssh_interface           = "session_manager"
+//   source_ami_filter {
+//     filters = {
+//       name                = "al2023-ami-*-kernel-6.1-x86_64"
+//       root-device-type    = "ebs"
+//       virtualization-type = "hvm"
+//     }
+//     most_recent = true
+//     owners      = ["amazon"]
+//   }
 
-  source_ami_filter {
-    filters = {
-      name                = "al2023-ami-*-kernel-6.1-x86_64"
-      root-device-type    = "ebs"
-      virtualization-type = "hvm"
-    }
-    most_recent = true
-    owners      = ["amazon"]
-  }
+//   # Build a public AMI
+//   encrypt_boot = false
+//   ami_groups   = local.is_public ? ["all"] : []
+//   ami_regions  = [for region in local.ami_regions: region if region != var.aws_region]
 
-  # Build a public AMI
-  encrypt_boot = false
-  ami_groups   = local.is_public ? ["all"] : []
-  ami_regions  = [for region in local.ami_regions: region if region != var.aws_region]
+//   # Customize the volumes
+//   launch_block_device_mappings {
+//     device_name = "/dev/xvda"
+//     encrypted   = false
+//     volume_size = 35
+//     volume_type = "gp3"
+//     delete_on_termination = true
+//   }
 
-  # Customize the volumes
-  launch_block_device_mappings {
-    device_name = "/dev/xvda"
-    encrypted   = false
-    volume_size = 35
-    volume_type = "gp3"
-    delete_on_termination = true
-  }
+//   # Source instance tags.
+//   run_tags = {
+//     Name    = "Packer Builder: ${local.image_family}-al2023-${local.image_version}"
+//     Creator = "Packer"
+//   }
+//   run_volume_tags = {
+//     Creator = "Packer"
+//   }
 
-  # Source instance tags.
-  run_tags = {
-    Name    = "Packer Builder: ${local.image_family}-al2023-${local.image_version}"
-    Creator = "Packer"
-  }
-  run_volume_tags = {
-    Creator = "Packer"
-  }
+//   # Target AMI tags.
+//   tags = {
+//     Name    = "${local.image_family}-al2023-${local.image_version}"
+//     Creator = "Packer"
+//   }
+//   snapshot_tags = {
+//     Creator = "Packer"
+//   }
+// }
 
-  # Target AMI tags.
-  tags = {
-    Name    = "${local.image_family}-al2023-${local.image_version}"
-    Creator = "Packer"
-  }
-  snapshot_tags = {
-    Creator = "Packer"
-  }
-}
+// source "amazon-ebs" "amazonlinux-2023-arm64" {
+//   ami_name                    = "${local.image_family}-al2023-arm64-${local.image_version}"
+//   ami_description             = "${local.image_description} arm64 (al2023)"
+//   instance_type               = var.aws_instance_type_arm64
+//   region                      = var.aws_region
+//   vpc_id                      = var.aws_vpc_id
+//   subnet_id                   = var.aws_subnet_id
+//   security_group_id           = var.aws_security_group_id
+//   iam_instance_profile        = var.aws_iam_instance_profile
+//   associate_public_ip_address = true
 
-source "amazon-ebs" "amazonlinux-2023-arm64" {
-  ami_name                    = "${local.image_family}-al2023-arm64-${local.image_version}"
-  ami_description             = "${local.image_description} arm64 (al2023)"
-  instance_type               = var.aws_instance_type_arm64
-  region                      = var.aws_region
-  vpc_id                      = var.aws_vpc_id
-  subnet_id                   = var.aws_subnet_id
-  security_group_id           = var.aws_security_group_id
-  iam_instance_profile        = var.aws_iam_instance_profile
-  associate_public_ip_address = true
+// 	temporary_key_pair_type = var.temporary_key_pair_type
+// 	ssh_username            = "ec2-user"
+//   ssh_interface           = "session_manager"
 
-	temporary_key_pair_type = var.temporary_key_pair_type
-	ssh_username            = "ec2-user"
-  ssh_interface           = "session_manager"
+//   source_ami_filter {
+//     filters = {
+//       name                = "al2023-ami-*-kernel-6.1-arm64"
+//       root-device-type    = "ebs"
+//       virtualization-type = "hvm"
+//     }
+//     most_recent = true
+//     owners      = ["amazon"]
+//   }
 
-  source_ami_filter {
-    filters = {
-      name                = "al2023-ami-*-kernel-6.1-arm64"
-      root-device-type    = "ebs"
-      virtualization-type = "hvm"
-    }
-    most_recent = true
-    owners      = ["amazon"]
-  }
+//   # Build a public AMI
+//   encrypt_boot = false
+//   ami_groups   = local.is_public ? ["all"] : []
+//   ami_regions  = [for region in local.ami_regions: region if region != var.aws_region]
 
-  # Build a public AMI
-  encrypt_boot = false
-  ami_groups   = local.is_public ? ["all"] : []
-  ami_regions  = [for region in local.ami_regions: region if region != var.aws_region]
+//   # Customize the volumes
+//   launch_block_device_mappings {
+//     device_name = "/dev/xvda"
+//     encrypted   = false
+//     volume_size = 35
+//     volume_type = "gp3"
+//     delete_on_termination = true
+//   }
 
-  # Customize the volumes
-  launch_block_device_mappings {
-    device_name = "/dev/xvda"
-    encrypted   = false
-    volume_size = 35
-    volume_type = "gp3"
-    delete_on_termination = true
-  }
+//   # Source instance tags.
+//   run_tags = {
+//     Name    = "Packer Builder: ${local.image_family}-al2023-arm64-${local.image_version}"
+//     Creator = "Packer"
+//   }
+//   run_volume_tags = {
+//     Creator = "Packer"
+//   }
 
-  # Source instance tags.
-  run_tags = {
-    Name    = "Packer Builder: ${local.image_family}-al2023-arm64-${local.image_version}"
-    Creator = "Packer"
-  }
-  run_volume_tags = {
-    Creator = "Packer"
-  }
-
-  # Target AMI tags.
-  tags = {
-    Name    = "${local.image_family}-al2023-arm64-${local.image_version}"
-    Creator = "Packer"
-  }
-  snapshot_tags = {
-    Creator = "Packer"
-  }
-}
+//   # Target AMI tags.
+//   tags = {
+//     Name    = "${local.image_family}-al2023-arm64-${local.image_version}"
+//     Creator = "Packer"
+//   }
+//   snapshot_tags = {
+//     Creator = "Packer"
+//   }
+// }

--- a/packer/aws.pkr.hcl
+++ b/packer/aws.pkr.hcl
@@ -1,5 +1,6 @@
 # Settings for AWS
 variable "aws_instance_type" { default = "t3.small" }
+variable "aws_instance_type_arm64" { default = "t4g.small" }
 variable "aws_region" { default = "us-west-2" }
 variable "aws_vpc_id" { default = "vpc-083b7145ef48f1f6d" }
 variable "aws_subnet_id" { default = "subnet-01ebe232b391d652b" }
@@ -204,6 +205,122 @@ source "amazon-ebs" "ubuntu-22" {
   }
 }
 
+source "amazon-ebs" "ubuntu-20-arm64" {
+  ami_name                    = "${local.image_family}-ubuntu20-arm64-${local.image_version}"
+  ami_description             = "${local.image_description} arm64 (ubuntu20)"
+  instance_type               = var.aws_instance_type_arm64
+  region                      = var.aws_region
+  vpc_id                      = var.aws_vpc_id
+  subnet_id                   = var.aws_subnet_id
+  security_group_id           = var.aws_security_group_id
+  iam_instance_profile        = var.aws_iam_instance_profile
+  associate_public_ip_address = true
+
+	temporary_key_pair_type = var.temporary_key_pair_type
+	ssh_username            = "ubuntu"
+  ssh_interface           = "session_manager"
+
+  source_ami_filter {
+    filters = {
+      name                = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
+    most_recent = true
+    owners      = local.ubuntu_owners
+  }
+
+  # Build a public AMI
+  encrypt_boot = false
+  ami_groups   = local.is_public ? ["all"] : []
+  ami_regions  = [for region in local.ami_regions: region if region != var.aws_region]
+
+  # Customize the volumes
+  launch_block_device_mappings {
+    device_name = "/dev/sda1"
+    encrypted   = false
+    volume_size = 35
+    volume_type = "gp3"
+    delete_on_termination = true
+  }
+
+  # Source instance tags.
+  run_tags = {
+    Name    = "Packer Builder: ${local.image_family}-ubuntu20-arm64-${local.image_version}"
+    Creator = "Packer"
+  }
+  run_volume_tags = {
+    Creator = "Packer"
+  }
+
+  # Target AMI tags.
+  tags = {
+    Name    = "${local.image_family}-ubuntu20-arm64-${local.image_version}"
+    Creator = "Packer"
+  }
+  snapshot_tags = {
+    Creator = "Packer"
+  }
+}
+
+source "amazon-ebs" "ubuntu-22-arm64" {
+  ami_name                    = "${local.image_family}-ubuntu22-arm64_${local.image_version}"
+  ami_description             = "${local.image_description} arm64 (ubuntu22)"
+  instance_type               = var.aws_instance_type_arm64
+  region                      = var.aws_region
+  vpc_id                      = var.aws_vpc_id
+  subnet_id                   = var.aws_subnet_id
+  security_group_id           = var.aws_security_group_id
+  iam_instance_profile        = var.aws_iam_instance_profile
+  associate_public_ip_address = true
+
+	temporary_key_pair_type = var.temporary_key_pair_type
+	ssh_username            = "ubuntu"
+  ssh_interface           = "session_manager"
+
+  source_ami_filter {
+    filters = {
+      name                = "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
+    most_recent = true
+    owners      = local.ubuntu_owners
+  }
+
+  # Build a public AMI
+  encrypt_boot = false
+  ami_groups   = local.is_public ? ["all"] : []
+  ami_regions  = [for region in local.ami_regions: region if region != var.aws_region]
+
+  # Customize the volumes
+  launch_block_device_mappings {
+    device_name = "/dev/sda1"
+    encrypted   = false
+    volume_size = 35
+    volume_type = "gp3"
+    delete_on_termination = true
+  }
+
+  # Source instance tags.
+  run_tags = {
+    Name    = "Packer Builder: ${local.image_family}-ubuntu22-arm64-${local.image_version}"
+    Creator = "Packer"
+  }
+  run_volume_tags = {
+    Creator = "Packer"
+  }
+
+  # Target AMI tags.
+  tags = {
+    Name    = "${local.image_family}-ubuntu22-arm64-${local.image_version}"
+    Creator = "Packer"
+  }
+  snapshot_tags = {
+    Creator = "Packer"
+  }
+}
+
 source "amazon-ebs" "amazonlinux-2" {
   ami_name                    = "${local.image_family}-amazonlinux2-${local.image_version}"
   ami_description             = "${local.image_description} (amazonlinux2)"
@@ -255,6 +372,181 @@ source "amazon-ebs" "amazonlinux-2" {
   # Target AMI tags.
   tags = {
     Name    = "${local.image_family}-amazonlinux2-${local.image_version}"
+    Creator = "Packer"
+  }
+  snapshot_tags = {
+    Creator = "Packer"
+  }
+}
+
+source "amazon-ebs" "amazonlinux-2-arm64" {
+  ami_name                    = "${local.image_family}-amazonlinux2-arm64-${local.image_version}"
+  ami_description             = "${local.image_description} arm64 (amazonlinux2)"
+  instance_type               = var.aws_instance_type_arm64
+  region                      = var.aws_region
+  vpc_id                      = var.aws_vpc_id
+  subnet_id                   = var.aws_subnet_id
+  security_group_id           = var.aws_security_group_id
+  iam_instance_profile        = var.aws_iam_instance_profile
+  associate_public_ip_address = true
+
+	temporary_key_pair_type = var.temporary_key_pair_type
+	ssh_username            = "ec2-user"
+  ssh_interface           = "session_manager"
+
+  source_ami_filter {
+    filters = {
+      name                = "amzn2-ami-kernel-5.10-hvm-*-arm64-gp2"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
+    most_recent = true
+    owners      = ["amazon"]
+  }
+
+  # Build a public AMI
+  encrypt_boot = false
+  ami_groups   = local.is_public ? ["all"] : []
+  ami_regions  = [for region in local.ami_regions: region if region != var.aws_region]
+
+  # Customize the volumes
+  launch_block_device_mappings {
+    device_name = "/dev/xvda"
+    encrypted   = false
+    volume_size = 35
+    volume_type = "gp3"
+    delete_on_termination = true
+  }
+
+  # Source instance tags.
+  run_tags = {
+    Name    = "Packer Builder: ${local.image_family}-amazonlinux2-arm64-${local.image_version}"
+    Creator = "Packer"
+  }
+  run_volume_tags = {
+    Creator = "Packer"
+  }
+
+  # Target AMI tags.
+  tags = {
+    Name    = "${local.image_family}-amazonlinux2-arm64-${local.image_version}"
+    Creator = "Packer"
+  }
+  snapshot_tags = {
+    Creator = "Packer"
+  }
+}
+
+
+source "amazon-ebs" "amazonlinux-2" {
+  ami_name                    = "${local.image_family}-al2023-${local.image_version}"
+  ami_description             = "${local.image_description} (al2023)"
+  instance_type               = var.aws_instance_type
+  region                      = var.aws_region
+  vpc_id                      = var.aws_vpc_id
+  subnet_id                   = var.aws_subnet_id
+  security_group_id           = var.aws_security_group_id
+  iam_instance_profile        = var.aws_iam_instance_profile
+  associate_public_ip_address = true
+
+	temporary_key_pair_type = var.temporary_key_pair_type
+	ssh_username            = "ec2-user"
+  ssh_interface           = "session_manager"
+
+  source_ami_filter {
+    filters = {
+      name                = "al2023-ami-*-kernel-6.1-x86_64"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
+    most_recent = true
+    owners      = ["amazon"]
+  }
+
+  # Build a public AMI
+  encrypt_boot = false
+  ami_groups   = local.is_public ? ["all"] : []
+  ami_regions  = [for region in local.ami_regions: region if region != var.aws_region]
+
+  # Customize the volumes
+  launch_block_device_mappings {
+    device_name = "/dev/xvda"
+    encrypted   = false
+    volume_size = 35
+    volume_type = "gp3"
+    delete_on_termination = true
+  }
+
+  # Source instance tags.
+  run_tags = {
+    Name    = "Packer Builder: ${local.image_family}-al2023-${local.image_version}"
+    Creator = "Packer"
+  }
+  run_volume_tags = {
+    Creator = "Packer"
+  }
+
+  # Target AMI tags.
+  tags = {
+    Name    = "${local.image_family}-al2023-${local.image_version}"
+    Creator = "Packer"
+  }
+  snapshot_tags = {
+    Creator = "Packer"
+  }
+}
+
+source "amazon-ebs" "amazonlinux-2-arm64" {
+  ami_name                    = "${local.image_family}-al2023-arm64-${local.image_version}"
+  ami_description             = "${local.image_description} arm64 (al2023)"
+  instance_type               = var.aws_instance_type_arm64
+  region                      = var.aws_region
+  vpc_id                      = var.aws_vpc_id
+  subnet_id                   = var.aws_subnet_id
+  security_group_id           = var.aws_security_group_id
+  iam_instance_profile        = var.aws_iam_instance_profile
+  associate_public_ip_address = true
+
+	temporary_key_pair_type = var.temporary_key_pair_type
+	ssh_username            = "ec2-user"
+  ssh_interface           = "session_manager"
+
+  source_ami_filter {
+    filters = {
+      name                = "al2023-ami-*-kernel-6.1-arm64"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
+    most_recent = true
+    owners      = ["amazon"]
+  }
+
+  # Build a public AMI
+  encrypt_boot = false
+  ami_groups   = local.is_public ? ["all"] : []
+  ami_regions  = [for region in local.ami_regions: region if region != var.aws_region]
+
+  # Customize the volumes
+  launch_block_device_mappings {
+    device_name = "/dev/xvda"
+    encrypted   = false
+    volume_size = 35
+    volume_type = "gp3"
+    delete_on_termination = true
+  }
+
+  # Source instance tags.
+  run_tags = {
+    Name    = "Packer Builder: ${local.image_family}-al2023-arm64-${local.image_version}"
+    Creator = "Packer"
+  }
+  run_volume_tags = {
+    Creator = "Packer"
+  }
+
+  # Target AMI tags.
+  tags = {
+    Name    = "${local.image_family}-al2023-arm64-${local.image_version}"
     Creator = "Packer"
   }
   snapshot_tags = {

--- a/packer/aws.pkr.hcl
+++ b/packer/aws.pkr.hcl
@@ -438,7 +438,7 @@ source "amazon-ebs" "amazonlinux-2-arm64" {
 }
 
 
-source "amazon-ebs" "amazonlinux-2" {
+source "amazon-ebs" "amazonlinux-2023" {
   ami_name                    = "${local.image_family}-al2023-${local.image_version}"
   ami_description             = "${local.image_description} (al2023)"
   instance_type               = var.aws_instance_type
@@ -496,7 +496,7 @@ source "amazon-ebs" "amazonlinux-2" {
   }
 }
 
-source "amazon-ebs" "amazonlinux-2-arm64" {
+source "amazon-ebs" "amazonlinux-2023-arm64" {
   ami_name                    = "${local.image_family}-al2023-arm64-${local.image_version}"
   ami_description             = "${local.image_description} arm64 (al2023)"
   instance_type               = var.aws_instance_type_arm64

--- a/packer/gen-native-images.sh
+++ b/packer/gen-native-images.sh
@@ -38,6 +38,9 @@ do
             s/ubuntu-/Ubuntu/g
         ')"
 
+        arch="amd64"
+        [ "${name/arm64/}" != "arm64" ] && arch="arm64"
+
         echo "
 $nicename images:"
         artifacts="$(
@@ -87,7 +90,8 @@ $nicename images:"
     \"ImageId\": \"${image}\",
     \"Region\": \"${region}\",
     \"Username\": \"${user}\",
-    \"Agent\": 0
+    \"Agent\": 0,
+    \"Arch\": \"${arch}\"
   }"    
         done
     done

--- a/packer/gen-native-images.sh
+++ b/packer/gen-native-images.sh
@@ -39,7 +39,8 @@ do
         ')"
 
         arch="amd64"
-        [ "${name/arm64/}" != "arm64" ] && arch="arm64"
+        [ "${name/arm64/}" != $name ] && arch="arm64"
+        nicename="${nicename/-arm64/ (arm64)}"
 
         echo "
 $nicename images:"
@@ -99,7 +100,8 @@ done
 
 echo "[$json
 ]" >snippet-temp.json
-jq '. | map(select(.Name == "Docker-Duplo-Oregon-Ubuntu22") | .Name = "Docker-Duplo") + .' <snippet-temp.json >snippet-NativeImages.json
+jq '. | map(select(.Name == "Docker-Duplo-Oregon-Ubuntu22" and .Arch == "amd64") | .Name = "Docker-Duplo") + .' <snippet-temp.json >snippet-temp2.json
+jq '. | map(select(.Name == "Docker-Duplo-Oregon-Ubuntu22 (arm64)" and .Arch == "arm64") | .Name = "Docker-Duplo (arm64)") + .' <snippet-temp2.json >snippet-NativeImages.json
 out "NativeImages JSON: snippet done"
 
 # Step 2 - Build a new native images JSON

--- a/packer/main.pkr.hcl
+++ b/packer/main.pkr.hcl
@@ -27,8 +27,8 @@ build {
 		"sources.amazon-ebs.ubuntu-22-arm64",
 		"sources.amazon-ebs.amazonlinux-2",
 		"sources.amazon-ebs.amazonlinux-2-arm64",
-		"sources.amazon-ebs.amazonlinux-2023",
-		"sources.amazon-ebs.amazonlinux-2023-arm64",
+//		"sources.amazon-ebs.amazonlinux-2023",
+//		"sources.amazon-ebs.amazonlinux-2023-arm64",
 		"sources.googlecompute.ubuntu-20",
 		"sources.googlecompute.ubuntu-22"
 	]
@@ -61,8 +61,8 @@ build {
 			"DOWNLOAD_REF=${var.agent_git_ref}"
 		]
 		only   = [
-			"amazon-ebs.amazonlinux-2", "amazon-ebs.amazonlinux-2023",
-			"amazon-ebs.amazonlinux-2-arm64", "amazon-ebs.amazonlinux-2023-arm64"
+			"amazon-ebs.amazonlinux-2", "amazon-ebs.amazonlinux-2-arm64",
+			// "amazon-ebs.amazonlinux-2023", "amazon-ebs.amazonlinux-2023-arm64"
 		]
 	}
 
@@ -102,8 +102,8 @@ build {
 			"sudo rm -rf /home/ec2-user/.history /home/ec2-user/authorized_keys", // user history and SSH authorized keys
 		]
 		only   = [
-			"amazon-ebs.amazonlinux-2", "amazon-ebs.amazonlinux-2023",
-			"amazon-ebs.amazonlinux-2-arm64", "amazon-ebs.amazonlinux-2023-arm64"
+			"amazon-ebs.amazonlinux-2", "amazon-ebs.amazonlinux-2-arm64",
+			// "amazon-ebs.amazonlinux-2023", "amazon-ebs.amazonlinux-2023-arm64"
 		]
 	}
 

--- a/packer/main.pkr.hcl
+++ b/packer/main.pkr.hcl
@@ -23,7 +23,12 @@ build {
 		"sources.amazon-ebs.ubuntu-18",
 		"sources.amazon-ebs.ubuntu-20",
 		"sources.amazon-ebs.ubuntu-22",
+		"sources.amazon-ebs.ubuntu-20-arm64",
+		"sources.amazon-ebs.ubuntu-22-arm64",
 		"sources.amazon-ebs.amazonlinux-2",
+		"sources.amazon-ebs.amazonlinux-2-arm64",
+		"sources.amazon-ebs.amazonlinux-2023",
+		"sources.amazon-ebs.amazonlinux-2023-arm64",
 		"sources.googlecompute.ubuntu-20",
 		"sources.googlecompute.ubuntu-22"
 	]
@@ -44,6 +49,7 @@ build {
 		environment_vars = [ "DEBIAN_FRONTEND=noninteractive" ]
 		only   = [
 			"amazon-ebs.ubuntu-18", "amazon-ebs.ubuntu-20", "amazon-ebs.ubuntu-22",
+			"amazon-ebs.ubuntu-20-arm64", "amazon-ebs.ubuntu-22-arm64",
 			"googlecompute.ubuntu-20", "googlecompute.ubuntu-22"
 		]
 	}
@@ -54,7 +60,10 @@ build {
 		environment_vars = [
 			"DOWNLOAD_REF=${var.agent_git_ref}"
 		]
-		only   = [ "amazon-ebs.amazonlinux-2" ]
+		only   = [
+			"amazon-ebs.amazonlinux-2", "amazon-ebs.amazonlinux-2023",
+			"amazon-ebs.amazonlinux-2-arm64", "amazon-ebs.amazonlinux-2023-arm64"
+		]
 	}
 
 	// Install - Ubuntu 18
@@ -74,7 +83,7 @@ build {
 			"DOWNLOAD_REF=${var.agent_git_ref}",
 			"DEBIAN_FRONTEND=noninteractive"
 		]
-		only   = [ "amazon-ebs.ubuntu-20", "googlecompute.ubuntu-20" ]
+		only   = [ "amazon-ebs.ubuntu-20", "amazon-ebs.ubuntu-20-arm64", "googlecompute.ubuntu-20" ]
 	}
 
 	// Install - Ubuntu 22
@@ -84,7 +93,7 @@ build {
 			"DOWNLOAD_REF=${var.agent_git_ref}",
 			"DEBIAN_FRONTEND=noninteractive"
 		]
-		only   = [ "amazon-ebs.ubuntu-22", "googlecompute.ubuntu-22" ]
+		only   = [ "amazon-ebs.ubuntu-22", "amazon-ebs.ubuntu-22-arm64", "googlecompute.ubuntu-22" ]
 	}
 
 	// Cleanup - Amazon Linux
@@ -92,7 +101,10 @@ build {
 		inline = [ 
 			"sudo rm -rf /home/ec2-user/.history /home/ec2-user/authorized_keys", // user history and SSH authorized keys
 		]
-		only   = [ "amazon-ebs.amazonlinux-2" ]
+		only   = [
+			"amazon-ebs.amazonlinux-2", "amazon-ebs.amazonlinux-2023",
+			"amazon-ebs.amazonlinux-2-arm64", "amazon-ebs.amazonlinux-2023-arm64"
+		]
 	}
 
 	// Cleanup - Ubuntu
@@ -102,6 +114,7 @@ build {
 		]
 		only   = [
 			"amazon-ebs.ubuntu-18", "amazon-ebs.ubuntu-20", "amazon-ebs.ubuntu-22",
+			"amazon-ebs.ubuntu-20-arm64", "amazon-ebs.ubuntu-22-arm64",
 			"googlecompute.ubuntu-20", "googlecompute.ubuntu-22"
 		]
 	}


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Added support for ARM64 architecture in Docker native image generation, including architecture detection and output.
- Introduced ARM64 builds for Ubuntu 20, Ubuntu 22, Amazon Linux 2, and Amazon Linux 2023 in AWS Packer configurations.
- Updated the main Packer build configuration to include ARM64 versions and adjusted provisioner settings accordingly.
- Modified the GitHub Actions workflow to exclude Ubuntu 18 from the build process, facilitating ARM64 build integration.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gen-native-images.sh</strong><dd><code>Add Architecture Detection and Output for Docker Native Images</code>&nbsp; </dd></summary>
<hr>
      
packer/gen-native-images.sh

<li>Added architecture detection for generating Docker native images, <br>defaulting to <code>amd64</code> and switching to <code>arm64</code> if the name contains <code>arm64</code>.<br> <li> Included the <code>Arch</code> field in the output JSON for each image, specifying <br>the architecture.


</details>

  </td>
  <td><a href="https://github.com/duplocloud/linuxagent/pull/38/files#diff-e08f30cee286b130e7e8e7c613ede59e4d1121281a8dbc0d96d9850091dd3400">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>aws.pkr.hcl</strong><dd><code>Support ARM64 Builds in AWS Packer Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
packer/aws.pkr.hcl

<li>Introduced a new variable <code>aws_instance_type_arm64</code> for ARM64 instance <br>types.<br> <li> Added new sources for Ubuntu 20, Ubuntu 22, Amazon Linux 2, and Amazon <br>Linux 2023 ARM64 builds.<br> <li> Configured AMI and instance settings for ARM64 builds, including AMI <br>names, descriptions, and instance types.


</details>

  </td>
  <td><a href="https://github.com/duplocloud/linuxagent/pull/38/files#diff-8b973bb1b8b6eca695987b76c44d9e45533fbcd46442a1bf467ebd14d08758c9">+292/-0</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>main.pkr.hcl</strong><dd><code>Integrate ARM64 Builds into Main Packer Build Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
packer/main.pkr.hcl

<li>Updated build sources to include ARM64 versions for Ubuntu and Amazon <br>Linux.<br> <li> Adjusted provisioner settings to support ARM64 builds.<br> <li> Modified cleanup provisioners to include ARM64 builds.


</details>

  </td>
  <td><a href="https://github.com/duplocloud/linuxagent/pull/38/files#diff-3d1058c7ed97baf9315bd849c7bc19f3f68d7d11f2bf014451e64b1493bf2432">+17/-4</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-image.yaml</strong><dd><code>Update GitHub Actions Workflow to Support ARM64 Builds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
.github/workflows/build-image.yaml

<li>Modified the GitHub Actions workflow to exclude Ubuntu 18 from the <br>build process.


</details>

  </td>
  <td><a href="https://github.com/duplocloud/linuxagent/pull/38/files#diff-13dcc6280edb5eae2f3bd75bb42234c54692d3ad42f4320b33286dcc5c95fa03">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
