### PR TITLE
Adding trusted host param for pip install

### DIFF
--- a/AgentAmazonLinux2/Setup.sh
+++ b/AgentAmazonLinux2/Setup.sh
@@ -43,12 +43,12 @@ py3Install () {
 
   # install virtualenv flask
   virtualenv flask
-  yes | flask/bin/pip install flask
-  yes | flask/bin/pip install requests
-  yes | flask/bin/pip install python-pytun
-  yes | flask/bin/pip install --upgrade python-iptables
-  yes | flask/bin/pip install docker
-  yes | flask/bin/pip install boto3
+  yes | flask/bin/pip --trusted-host pypi.python.org install flask
+  yes | flask/bin/pip --trusted-host pypi.python.org install requests
+  yes | flask/bin/pip --trusted-host pypi.python.org install python-pytun
+  yes | flask/bin/pip --trusted-host pypi.python.org install --upgrade python-iptables
+  yes | flask/bin/pip --trusted-host pypi.python.org install docker
+  yes | flask/bin/pip --trusted-host pypi.python.org install boto3
 
    #########
    cd $DAEMON_DIR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2024-08-13
+
+### Changed
+- Added `--trusted-host pypi.python.org` parameter to all `pip install` commands in the Amazon Linux 2 setup script for improved consistency and reliability.
+
 ## 2024-04-18
 
 ### Added


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added `--trusted-host pypi.python.org` parameter to `pip install` commands in `AgentAmazonLinux2/Setup.sh`.
- Ensured that all `pip install` commands in the script use the trusted host parameter for consistency and reliability.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Setup.sh</strong><dd><code>Add trusted host parameter to pip install commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

AgentAmazonLinux2/Setup.sh

<li>Added <code>--trusted-host pypi.python.org</code> parameter to multiple <code>pip install</code> <br>commands.<br> <li> Ensured all <code>pip install</code> commands use the trusted host parameter for <br>consistency.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/linuxagent/pull/41/files#diff-cc6e628cc2fbfdbc807fa9eed4c2684eacb3ceae88a39d7ab1a92c239489fdab">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

